### PR TITLE
add coffee-script dep to package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,2 @@
-require("coffee-script")
+require("coffee-script/register")
 module.exports = require("./lib/index.coffee")

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generic-pool": "^2.1.1",
     "underscore": "^1.7.0",
     "underscore.deep": "^0.5.1",
-    "coffee-script": "1.6.2"
+    "coffee-script": "~1.8.0"
   },
   "devDependencies": {
     "clever-coffeescript-style-guide": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "debug": "^2.1.1",
     "generic-pool": "^2.1.1",
     "underscore": "^1.7.0",
-    "underscore.deep": "^0.5.1"
+    "underscore.deep": "^0.5.1",
+    "coffee-script": "1.6.2"
   },
   "devDependencies": {
     "clever-coffeescript-style-guide": "^0.2.0",


### PR DESCRIPTION
realized this wasn't in the package.json already when some projects using a newer version of CS gave errors on startup

v1.8+ gives:

```
Error: Use CoffeeScript.register() or require the coffee-script/register module to require .coffee.md files.
```

v1.7.x gives:

```
/Users/rbarry/thrift-pool/lib/index.coffee:1
ion (exports, require, module, __filename, __dirname) { _ = require "underscor
                                                                    ^^^^^^^^^^^^
SyntaxError: Unexpected string
```
