### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
Otherwise, NPM uses .gitignore as .npmignore, which would cause index.js to
not be included in the published package.
