### PR TITLE
Add option to retry on ECONNRESET or connection close

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TESTS=$(shell cd test && ls *.coffee | sed s/\.coffee$$//)
 build: index.js
 
 index.js: lib/index.coffee
-	node_modules/coffee-script/bin/coffee --bare -o . -c lib/index.coffee
+	node_modules/coffee-script/bin/coffee --bare --map -o . -c lib/index.coffee
 
 test: $(TESTS) lint
 

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,6 @@ SHELL := /bin/bash
 
 TESTS=$(shell cd test && ls *.coffee | sed s/\.coffee$$//)
 
-build: index.js
-
-index.js: lib/index.coffee
-	node_modules/coffee-script/bin/coffee --bare --map -o . -c lib/index.coffee
-
 test: $(TESTS) lint
 
 lint:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Options to use when creating pool, defaults match those used by node-pool.
 - `port` - **Required** - The port of the thrift server to connect to
 - `max_connections` - Default: `1` - Max number of connections to keep open at any given time
 - `min_connections` - Default: `0` - Min number of connections to keep open at any given time
-- `idle_timeout` - Default: `30000` - Time (ms) to wait until closing idle connections
+- `idle_timeout` - Default: `10000` - Time (ms) to wait until closing idle connections
+- `retries` - Default: `2` - Number of times to retry if the connection fails
 
 ## Thrift options - optional
 All thrift options are supported and can be passed in as an object in addition to the pooling options.

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -1,12 +1,14 @@
-_ = require "underscore"
-_.mixin require "underscore.deep"
-async = require "async"
+_ = require "lodash"
 genericPool = require "generic-pool"
 debug = require("debug")("thrift-pool")
 
 TIMEOUT_MESSAGE = "Thrift-pool: Connection timeout"
 CLOSE_MESSAGE = "Thrift-pool: Connection closed"
 
+class ClosedError extends Error
+  closed: true
+
+id = 0
 # create_cb creates and initializes a connection
 #  @param thrift, used to create connection
 #  @param pool_options, host and port used to create connection
@@ -15,6 +17,7 @@ create_cb = (thrift, pool_options, thrift_options, cb) ->
   cb = _.once cb
   connection = thrift.createConnection pool_options.host, pool_options.port, thrift_options
   connection.__ended = false
+  connection.__id = id += 1
   connection.on "connect", ->
     debug "in connect callback"
     connection.connection.setKeepAlive(true)
@@ -22,11 +25,12 @@ create_cb = (thrift, pool_options, thrift_options, cb) ->
   connection.on "error", (err) ->
     debug "in error callback"
     connection.__ended = true
+    debug {err, connection_id: connection.__id}
     cb err
   connection.on "close", ->
     debug "in close callback"
     connection.__ended = true
-    cb new Error CLOSE_MESSAGE
+    cb new ClosedError CLOSE_MESSAGE
   # timeout listener only applies if timeout is passed into thrift_options
   if thrift_options.timeout?
     debug "adding timeout listener"
@@ -55,14 +59,27 @@ create_pool = (thrift, pool_options = {}, thrift_options = {}) ->
     min: pool_options.min_connections
     idleTimeoutMillis: pool_options.idle_timeout
 
+retry_fn = (num_retries, is_retryable, fn, cb) ->
+  fn (err, result) ->
+    if err
+      debug {err}
+      debug {num_retries, is_retryable: is_retryable err}
+    if not err or not is_retryable(err) or num_retries <= 0
+      debug 'calling callback'
+      cb err, result
+    else
+      debug 'retrying'
+      retry_fn num_retries - 1, is_retryable, fn, cb
+
 module.exports = (thrift, service, pool_options = {}, thrift_options = {}) ->
 
   throw new Error "Thrift-pool: You must specify #{key}" for key in ["host", "port"] when not pool_options[key]
 
-  pool_options = _(pool_options).defaults
+  pool_options = _.defaults pool_options,
     max_connections: 1 # Max number of connections to keep open at any given time
     min_connections: 0 # Min number of connections to keep open at any given time
-    idle_timeout: 30000 # Time (ms) to wait until closing idle connections
+    idle_timeout: 10000 # Time (ms) to wait until closing idle connections
+    retries: 2
 
   pool = create_pool thrift, pool_options, thrift_options
 
@@ -88,29 +105,31 @@ module.exports = (thrift, service, pool_options = {}, thrift_options = {}) ->
     if thrift_options.timeout?
       connection.removeListener "timeout", cb_timeout
 
-  # wrap_thrift_fn when called with a function and arguments/callback:
+  # wrap_thrift_attempt when called with a function and arguments/callback:
   #   - acquires a connection
   #   - adds additional connection event listeners
   #   - creates a client with the acquired connection
   #   - calls client with fn and passed args and callback
   #   - connection is released before results are returned
   #  @return, function that takes in arguments and a callback
-  wrap_thrift_fn = (fn) -> (args..., cb) ->
+  wrap_thrift_attempt = (fn) -> (args..., cb) ->
     pool.acquire (err, connection) ->
       debug "Connection acquired"
-      debug {err}
-      debug {connection}
+      debug {err, connection_id: connection?.__id} if err?
       return cb err if err?
       cb = _.once cb
       cb_error = (err) ->
         debug "in error callback, post-acquire listener"
+        debug {err, connection_id: connection.__id}
         cb err
       cb_timeout = ->
         debug "in timeout callback, post-acquire listener"
+        debug {err, connection_id: connection.__id}
         cb new Error TIMEOUT_MESSAGE
       cb_close = ->
         debug "in close callback, post-acquire listener"
-        cb new Error CLOSE_MESSAGE
+        debug {err, connection_id: connection.__id}
+        cb new ClosedError CLOSE_MESSAGE
       add_listeners connection, cb_error, cb_timeout, cb_close
       client = thrift.createClient service, connection
       debug "Client created"
@@ -121,13 +140,22 @@ module.exports = (thrift, service, pool_options = {}, thrift_options = {}) ->
         pool.release connection
         cb err, results...
 
-  # The following returns a new object with all of the keys of an
-  # initialized client class.
-  # Note: _.mapValues only supports "simple", "vanilla" objects that
-  # are not associated with a class.  Since service.Client.prototype
-  # does not fall into that category, need to call _.clone first
-  _.mapValues _.clone(service.Client.prototype), (fn, name) ->
-    wrap_thrift_fn name
+  should_retry = (err) ->
+    err.closed or err.code == 'ECONNRESET' or err.errno == 'ECONNRESET'
+
+  wrap_thrift_fn = (fn_name) ->
+    wrapped = wrap_thrift_attempt fn_name
+    (args..., callback) ->
+      call = (cb) -> wrapped args..., cb
+      retry_fn pool_options.retries, should_retry, call, callback
+
+  # The following returns a new object with all of the keys of an initialized
+  # client class.
+  _(service.Client.prototype)
+    .functions()
+    .map((name) -> [name, wrap_thrift_fn name])
+    .zipObject()
+    .value()
 
 # For unit testing
-_.extend module.exports, _private: {create_pool, TIMEOUT_MESSAGE, CLOSE_MESSAGE}
+_.extend module.exports, _private: {create_pool, retry_fn, TIMEOUT_MESSAGE, CLOSE_MESSAGE}

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -124,11 +124,11 @@ module.exports = (thrift, service, pool_options = {}, thrift_options = {}) ->
         cb err
       cb_timeout = ->
         debug "in timeout callback, post-acquire listener"
-        debug {err, connection_id: connection.__id}
+        debug {connection_id: connection.__id}
         cb new Error TIMEOUT_MESSAGE
       cb_close = ->
         debug "in close callback, post-acquire listener"
-        debug {err, connection_id: connection.__id}
+        debug {connection_id: connection.__id}
         cb new ClosedError CLOSE_MESSAGE
       add_listeners connection, cb_error, cb_timeout, cb_close
       client = thrift.createClient service, connection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-thrift-pool",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A module that wraps thrift interfaces in connection pooling logic to make them more resilient.",
   "main": "index.js",
   "scripts": {
@@ -12,8 +12,7 @@
     "async": "^0.9.0",
     "debug": "^2.1.1",
     "generic-pool": "^2.1.1",
-    "underscore": "^1.7.0",
-    "underscore.deep": "^0.5.1"
+    "lodash": "^3.10.1"
   },
   "devDependencies": {
     "clever-coffeescript-style-guide": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,12 @@
     "async": "^0.9.0",
     "debug": "^2.1.1",
     "generic-pool": "^2.1.1",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "coffee-script": "~1.8.0"
   },
   "devDependencies": {
     "clever-coffeescript-style-guide": "^0.3.0",
     "coffee-errors": "^0.8.6",
-    "coffee-script": "~1.8.0",
     "mocha": "^2.0.1",
     "sinon": "^1.12.2"
   }


### PR DESCRIPTION
Both Node and external load balancers have a habit of being [temperamental](http://blog.gluwer.com/2014/03/story-of-eaddrinuse-and-econnreset-errors/) when it comes to long-lived sockets, so I've added a `pool_options.retries` option to attempt to retry any function call if the socket is closed or reset mid-call.

I believe there's also a minor race condition between the `close` handler and the `validate` method passed to the pool (namely around the value of `connection.__ended`), but this works around it without needing expensive/complicated locking or the like.
