### PR TITLE
Error in expiration validating of connections

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -61,7 +61,7 @@ create_pool = (thrift, pool_options = {}, thrift_options = {}) ->
       debug "in validate"
       return false if connection.__ended
       return true unless pool_options.ttl?
-      connection.__reap_time < Date.now()
+      connection.__reap_time > Date.now()
     log: pool_options.log
     max: pool_options.max_connections
     min: pool_options.min_connections


### PR DESCRIPTION
When use pool optino ttl, this line mistakes to determine the connection as expired. This make the pool repeatedly destroy and create connections in every cycle.

My service was also suffering a lot of zombie established thrift connections. I'll follow to check if the two problem coupled.
